### PR TITLE
I have a workaround for the postLayout issue. See the code and the commit comment for details

### DIFF
--- a/Classes/TiUIView+WithShadow.m
+++ b/Classes/TiUIView+WithShadow.m
@@ -69,6 +69,15 @@
 //this code is by Javier Rayon and was originally posted in the Titanium Q&A forum:
 //http://developer.appcelerator.com/question/130784/trick-drop-real-shadows-in-titanium-ios
 
+-(void)setClipsToBounds:(BOOL)clipsToBounds
+{
+    if (self.layer.shadowOpacity > 0) {
+        // if there is shadow, we regret to clip
+        [super setClipsToBounds:NO];
+    } else {
+        [super setClipsToBounds:clipsToBounds];
+    }
+}
 
 
 -(void)setShadow_:(id)args


### PR DESCRIPTION
...adow set

Overwriting the setClipsToBounds method to check shadowOpacity if view
has shadows or not. If yes, clipToBounds is not passed through.
Otherwise everything works as before.
